### PR TITLE
Add .j2 extension to basic-security.groovy, remove user and password …

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@
 # jenkins_version: "1.644"
 # jenkins_pkg_url: "https://www.example.com/"
 
+# Jenkins config vars
+java_home: /usr/bin/java
+jenkins_name: jenkins
 jenkins_connection_delay: 5
 jenkins_connection_retries: 60
 jenkins_home: /var/lib/jenkins
@@ -16,9 +19,13 @@ jenkins_plugins: []
 jenkins_url_prefix: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false -Dhudson.diyChunking=false"
 
-jenkins_admin_username: admin
-jenkins_admin_password: admin
-jenkins_admin_password_file: ""
+#jenkins_servlet_context: "/$NAME"
+#jenkins_standalone: true
+#jenkins_log: /var/log/$NAME/$NAME.log
+#jenkins_user: $NAME
+#jenkins_group: $NAME
+#jenkins_war: /usr/share/$NAME/$NAME.war
+#jenkins_pidfile: /var/run/$NAME/$NAME.pid
 
 jenkins_init_changes:
   - option: "JENKINS_ARGS"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,6 +4,6 @@
 
 - name: configure default users
   template:
-    src: basic-security.groovy
+    src: basic-security.groovy.j2
     dest: "{{ jenkins_home }}/init.groovy.d/basic-security.groovy"
   register: jenkins_users_config

--- a/templates/basic-security.groovy.j2
+++ b/templates/basic-security.groovy.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 #!groovy
 import hudson.security.*
 import jenkins.model.*
@@ -10,7 +11,7 @@ if (!instance.isUseSecurity()) {
     println "--> creating local user 'admin'"
 
     def hudsonRealm = new HudsonPrivateSecurityRealm(false)
-    hudsonRealm.createAccount('{{ jenkins_admin_username }}', '{{ jenkins_admin_password }}')
+    hudsonRealm.createAccount('{{ jenkins_admin_username | mandatory}}', '{{ jenkins_admin_password | mandatory}}')
     instance.setSecurityRealm(hudsonRealm)
 
     def strategy = new FullControlOnceLoggedInAuthorizationStrategy()

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,6 @@
 ---
-__jenkins_repo_url: deb http://pkg.jenkins.io/debian binary/
-__jenkins_repo_key_url: http://pkg.jenkins.io/debian/jenkins.io.key
+__jenkins_repo_url: deb http://pkg.jenkins.io/debian-stable binary/
+__jenkins_repo_key_url: https://pkg.jenkins.io/debian/jenkins-ci.org.key
 __jenkins_pkg_url: http://pkg.jenkins.io/debian/binary/
 jenkins_init_file: /etc/default/jenkins
 jenkins_http_port_param: HTTP_PORT


### PR DESCRIPTION
…and set them mandatory; keep settings.yml for now.
Changed jenkins package repository

settings.xml takes the jenkins config file and replaces several lines with the given parameters instead of writing a .j2 file that completely creates a new config file and replaces it. It also restarts jenkins when changing the config.